### PR TITLE
Allow kpasswd on Carbon

### DIFF
--- a/roles/openbsd/files/etc/pf.conf
+++ b/roles/openbsd/files/etc/pf.conf
@@ -74,6 +74,7 @@ pass in quick on $int_if proto tcp from 192.168.42.7 to madhax.net port 7700    
 pass in quick on $int_if proto tcp from 192.168.42.7 to smtp.utdallas.edu port 25        # So the account script can email
 pass in quick on $int_if proto tcp from 192.168.42.7 to any port 80                      # for the gem command (moves around on S3)
 pass in quick on $int_if proto tcp from 192.168.42.6 to any port {80 443 5222 6667 6697} # allow http, jabber, and IRC on carbon
+pass in quick on $int_if proto {tcp udp} from 192.168.42.6 to $DCs port 464              # Allow kpasswd on Carbon
 pass in quick on $int_if proto tcp from 192.168.42.8 to any port {80 443}                # O needs to check external services
 pass in quick on $int_if proto tcp from 192.168.42.10 to any port {80 443}               # Allow Ne to access web content
 pass in quick on $int_if proto tcp from $servers to 192.30.252.0/22 port 443             # Github for dotfiles and plugins


### PR DESCRIPTION
Exact line not tested, but eyeballed to work right. It may be desired to allow more traffic.
