### PR TITLE
Create a kiosk role for the announcement TV

### DIFF
--- a/roles/kiosk/files/startup
+++ b/roles/kiosk/files/startup
@@ -1,0 +1,3 @@
+SHELL=/bin/sh
+
+@reboot root sleep 1; xset dpms force off; su kiosk -c "startx -- :0 vt8 && chvt 8"

--- a/roles/kiosk/files/xinitrc
+++ b/roles/kiosk/files/xinitrc
@@ -1,0 +1,2 @@
+exec feh -g 1920x1080 -R 3 -D 3 -- /opt/announcements
+

--- a/roles/kiosk/tasks/main.yml
+++ b/roles/kiosk/tasks/main.yml
@@ -1,0 +1,9 @@
+---
+- name: Create a kiosk user
+  user: name=kiosk
+
+- name: Install xinitrc
+  copy: src=xinitrc dest=/home/kiosk/.xinitrc owner=kiosk group=kiosk mode=0750
+
+- name: Install reboot cron
+  copy: src=startup /etc/cron.d/startup owner=root group=root mode=0750


### PR DESCRIPTION
We have a new TV in town and it needs a role.  It has its own user and,
upon booting, will automagically start a feh script on tty8.
