### PR TITLE
Make Flourine's MPD output mono audio

### DIFF
--- a/roles/audio/files/mpd.conf
+++ b/roles/audio/files/mpd.conf
@@ -11,3 +11,9 @@ replaygain            "auto"
 volume_normalization  "yes"
 filesystem_charset    "UTF-8"
 id3v1_encoding        "UTF-8"
+audio_output {
+        type            "alsa"
+        name            "Sound Card"
+        mixer_type      "software"
+        format          "44100:16:1"
+}


### PR DESCRIPTION
Now we can listen to both the left and right track of our music, whether
we are on the quiet side or the social side!
