### PR TITLE
Have ALSA use mono audio on flourine

### DIFF
--- a/roles/audio/files/asound.conf
+++ b/roles/audio/files/asound.conf
@@ -1,0 +1,15 @@
+pcm.!default {
+	type route
+	slave.pcm card0
+	slave.channels 2
+	ttable.0.0 0.5
+	ttable.0.1 0.5
+	ttable.1.0 0.5
+	ttable.1.1 0.5
+}
+
+pcm.card0 {
+	type hw
+	card 0
+}
+

--- a/roles/audio/tasks/main.yml
+++ b/roles/audio/tasks/main.yml
@@ -21,3 +21,6 @@
   copy: src=audio.rules dest=/etc/iptables.d owner=root group=root mode=0640
   notify:
   - iptables
+
+- name: Configure Alsa with mono output
+  copy: src=asound.conf dest=/etc/asound.conf owner=root groupt=root mode=0644


### PR DESCRIPTION
Now we can listen to both channels of music without standing in the
doorway between the quiet and social side.
