### PR TITLE
Add zsh and tmux to base

### DIFF
--- a/install.site
+++ b/install.site
@@ -32,13 +32,13 @@ esac
 
 for file in /etc/dhcpd.conf /etc/hostname.* /etc/ntpd.conf /var/unbound/etc/unbound.conf; do
 	ed -s "$file" <<-EOF
-		s/{{ name }}/$name/
-		s/{{ internal_ip }}/$int_ip/
-		s/{{ external_ip }}/$ext_ip/
-		s/{{ pf_ip }}/$pf_ip/
-		s/{{ peer_internal_ip }}/$other_int_ip/
-		s/{{ advskew }}/$advskew/
-		s/{{ dhcpd_range }}/$dhcpd_range/
+		,s/{{ name }}/$name/
+		,s/{{ internal_ip }}/$int_ip/
+		,s/{{ external_ip }}/$ext_ip/
+		,s/{{ pf_ip }}/$pf_ip/
+		,s/{{ peer_internal_ip }}/$other_int_ip/
+		,s/{{ advskew }}/$advskew/
+		,s/{{ dhcpd_range }}/$dhcpd_range/
 		w
 	EOF
 done

--- a/roles/audio/tasks/main.yml
+++ b/roles/audio/tasks/main.yml
@@ -9,7 +9,6 @@
   - mpc
   - mpv
   - ncmpcpp
-  - tmux
 
 - name: Configure MPD
   copy: src=mpd.conf dest=/etc/mpd.conf owner=mpd group=audio mode=0640

--- a/roles/base/tasks/main.yml
+++ b/roles/base/tasks/main.yml
@@ -80,3 +80,9 @@
     - cv_real_users
     - cv_reboot
     - cv_screen_wake
+
+- name: Install zsh and tmux everywhere
+  apt: name={{ item }} state=present
+  with_items:
+    - tmux
+    - zsh

--- a/roles/ssh-box/tasks/main.yml
+++ b/roles/ssh-box/tasks/main.yml
@@ -7,19 +7,17 @@
 - name: Install ssh-box packages
   apt: pkg={{ item }} state=present
   with_items:
-  - bc
-  - git
-  - irssi
-  - mosh
-  - screen
-  - tmux
-  - zsh
-  # For SASL in irssi
-  - libcrypt-blowfish-perl
-  - libcrypt-dh-perl
-  - libcrypt-openssl-bignum-perl
-  # For jabber in weechat
-  - python-xmpp
+    - bc
+    - git
+    - irssi
+    - mosh
+    - screen
+    # For SASL in irssi
+    - libcrypt-blowfish-perl
+    - libcrypt-dh-perl
+    - libcrypt-openssl-bignum-perl
+    # For jabber in weechat
+    - python-xmpp
 
 - name: Add weechat repository
   apt_repository: repo=ppa:nesthib/weechat-stable update_cache=yes
@@ -27,8 +25,8 @@
 - name: Install weechat-dev
   apt: pkg={{ item }} state=present
   with_items:
-  - weechat-curses
-  - weechat-plugins
+    - weechat-curses
+    - weechat-plugins
 
 - name: Add pubkey help in zprofile
   file: src=zprofile dest=/etc/zsh/zprofile owner=root group=root mode=0644


### PR DESCRIPTION
This commit adds zsh and tmux to the base network configuration.  Many
services and admins use tmux. Since we added domain logins on the
servers, admins with their shell set to /bin/zsh will not be able to
login where it is not installed.
- This commit also fixes style in the files touched.
