### PR TITLE
Use "become" instead of "sudo" where possible

### DIFF
--- a/audio.yml
+++ b/audio.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: audio
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - base
   - audio

--- a/dc.yml
+++ b/dc.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: dc
-  sudo: yes
+  become: yes
+  become_method: sudo
   vars:
     init: false
   roles:

--- a/kiosk.yml
+++ b/kiosk.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: kiosk
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - kiosk

--- a/make-keytab.yml
+++ b/make-keytab.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: dc[0]
-  sudo: yes
+  become: yes
+  become_method: sudo
   vars_prompt:
     - name: "service"
       prompt: "Keytab Service"

--- a/minecraft.yml
+++ b/minecraft.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: minecraft
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - base
   - spigot

--- a/nas.yml
+++ b/nas.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: nas
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - nas

--- a/printserver.yml
+++ b/printserver.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: print
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - base
   - papercut

--- a/ssh-box.yml
+++ b/ssh-box.yml
@@ -1,6 +1,7 @@
 ---
 - hosts: ssh
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - base
   - ssh-box

--- a/update.yml
+++ b/update.yml
@@ -1,5 +1,6 @@
 ---
 - hosts: dc:ssh:utility:minecraft:audio:nut:print:mediaboxen:clients
-  sudo: yes
+  become: yes
+  become_method: sudo
   tasks:
   - apt: update_cache=yes upgrade=safe purge=yes

--- a/utility.yml
+++ b/utility.yml
@@ -3,7 +3,8 @@
   gather_facts: true
 
 - hosts: utility
-  sudo: yes
+  become: yes
+  become_method: sudo
   roles:
   - base
   - exim4


### PR DESCRIPTION
We are not currently doing this on the nut, or gateway roles.  We
should make sure this works on nut, and investigate other
alternatives for OpenBSD.
