### PR TITLE
Add trailing slash to http->https paper redirect

### DIFF
--- a/roles/papercut_site/files/paper.conf
+++ b/roles/papercut_site/files/paper.conf
@@ -1,6 +1,6 @@
 <VirtualHost *:80>
 	ServerName paper.collegiumv.org
-	Redirect permanent / https://paper.collegiumv.org
+	Redirect permanent / https://paper.collegiumv.org/
 </VirtualHost>
 
 <VirtualHost paper.collegiumv.org:443>


### PR DESCRIPTION
Previously, going to http://paper.collegiumv.org/something would
redirect to https://paper.collegiumv.orgsomething.  This is no longer
the case.
