### PR TITLE
Add ncurses-term package to ssh-box

### DIFF
--- a/roles/core-programs/tasks/main.yml
+++ b/roles/core-programs/tasks/main.yml
@@ -15,5 +15,6 @@
     - cyrus-sasl-modules-gssapi
     - dialog
     - htop
+    - ncurses-term
     - tmux
     - zsh


### PR DESCRIPTION
ncurses-term is an XBPS package containing terminfo files for tmux among others.