### PR TITLE
Add additional 32bit libraries.

### DIFF
--- a/roles/workstation/tasks/main.yml
+++ b/roles/workstation/tasks/main.yml
@@ -11,6 +11,7 @@
 - name: Install graphics libraries
   xbps:
     pkg:
+      - libtxc_dxtn-32bit
       - libXrandr-32bit
       - libXt-32bit
       - mesa-ati-dri-32bit
@@ -105,6 +106,7 @@
       - fuse-exfat
       - gnome-screenshot
       - gnupg2
+      - gnutls-32bit
       - google-fonts-ttf
       - htop
       - keepassx2


### PR DESCRIPTION
Certain legacy applications require 32bit gnutls and 32bit dxtn.