### PR TITLE
Add memberOf overlay to ldap

### DIFF
--- a/roles/slapd/templates/config.ldif
+++ b/roles/slapd/templates/config.ldif
@@ -22,6 +22,7 @@ olcModulePath: /usr/libexec/openldap
 olcModuleLoad: {0}back_mdb
 olcModuleLoad: {1}syncprov
 olcModuleLoad: {2}unique
+olcModuleLoad: {3}memberof
 
 dn: olcDatabase={-1}frontend,cn=config
 objectClass: olcDatabaseConfig
@@ -97,3 +98,8 @@ objectClass: olcUniqueConfig
 olcOverlay: {1}unique
 olcUniqueURI: ldap:///ou=People,dc=collegiumv,dc=org?netID?sub?
 olcUniqueURI: ldap:///ou=People,dc=collegiumv,dc=org?uidNumber?sub?
+
+dn: olcOverlay={2}memberof,olcDatabase={1}mdb,cn=config
+objectClass: olcMemberOf
+olcOverlay: {2}memberof
+olcMemberOfRefInt: TRUE


### PR DESCRIPTION
This commit adds the memberOf overlay to the slapd configuration.

This enables the memberOf attribute to be populated by openldap.

Groups (must) be deleted and readded for this to take effect