### PR TITLE
Remove refint from memberOf

### DIFF
--- a/roles/slapd/templates/config.ldif
+++ b/roles/slapd/templates/config.ldif
@@ -102,4 +102,3 @@ olcUniqueURI: ldap:///ou=People,dc=collegiumv,dc=org?uidNumber?sub?
 dn: olcOverlay={2}memberof,olcDatabase={1}mdb,cn=config
 objectClass: olcMemberOf
 olcOverlay: {2}memberof
-olcMemberOfRefInt: TRUE


### PR DESCRIPTION
This commit disables refInt from memberOf.

`slapcat` does not include the olcOverlay for memberOf, a
hypothesis for the reason behind this is that refint is not loaded
therefore, to test, it is recommended to delete the jira-users ldap
group and push with this commit, which should configure the olcOverlay
and then create the group...