### PR TITLE
Source /etc/profile from /etc/zprofile

### DIFF
--- a/roles/workstation/files/zprofile
+++ b/roles/workstation/files/zprofile
@@ -1,0 +1,1 @@
+emulate sh -c 'source /etc/profile'

--- a/roles/workstation/tasks/main.yml
+++ b/roles/workstation/tasks/main.yml
@@ -200,6 +200,14 @@
     group: root
     mode: 0644
 
+- name: Copy zprofile
+  copy:
+    src: zprofile
+    dest: /etc/zprofile
+    owner: root
+    group: root
+    mode: 0644
+
 - name: Copy sudoers file
   copy:
     src: cv.sudoers


### PR DESCRIPTION
SDDM doesn't source /etc/profile if your shell is zsh.  This is
important for setting the proper umask, locale, latex location, java
vars, etc.

This uses Arch's solution:
https://git.archlinux.org/svntogit/packages.git/tree/trunk/zprofile?h=packages/zsh