### PR TITLE
Add support for elogind to netlogin

### DIFF
--- a/roles/netlogon/files/system-auth
+++ b/roles/netlogon/files/system-auth
@@ -20,6 +20,8 @@ password  required    pam_deny.so
 session   optional    pam_umask.so    usergroups
 session   optional    pam_mount.so
 session   required    pam_limits.so
+session   optional    pam_ck_connector.so
+session   optional    pam_elogind.so
 session   sufficient  pam_unix.so
 session	  sufficient  pam_krb5.so
 session   required    pam_deny.so

--- a/roles/netlogon/tasks/main.yml
+++ b/roles/netlogon/tasks/main.yml
@@ -3,6 +3,7 @@
   xbps:
     pkg:
       - hxtools
+      - elogind
       - libnfs
       - mit-krb5
       - nfs-utils


### PR DESCRIPTION
`elogind` is required for sddm to properly configure permissions