### PR TITLE
Switch logout script to use loginctl

### DIFF
--- a/roles/workstation/files/kill-old-users.sh
+++ b/roles/workstation/files/kill-old-users.sh
@@ -4,7 +4,7 @@
 KILLSECONDS=2700
 
 export DISPLAY=":0.0"
-PERSON=$(who | grep ":0" | cut -d" " -f 1)
+PERSON=$(loginctl | awk '/seat0/ {print $3;exit}')
 LOCKEDTIME=0
 
 if pgrep -u "$PERSON" cinnamon-screen ; then #we check for the shotened name as that's what pgrep returns


### PR DESCRIPTION
Works as long as 'switch user' has not been performed yet; I assume this is what the old script did, as it relies on how long the screensaver has been on