### PR TITLE
Added missing 32-bit libraries

### DIFF
--- a/roles/workstation/tasks/main.yml
+++ b/roles/workstation/tasks/main.yml
@@ -12,6 +12,8 @@
 - name: Install graphics libraries
   xbps:
     pkg:
+      - libpng12-32bit
+      - libtxc_dxtn-32bit
       - libXrandr-32bit
       - libXt-32bit
       - libXxf86vm-32bit


### PR DESCRIPTION
libpng12 is a legacy libpng library and libtxc_dxtn is a helper library for Mesa